### PR TITLE
Upgrade swupdate.bbclass in morty from master.

### DIFF
--- a/README
+++ b/README
@@ -21,18 +21,34 @@ image filename) are replaced with the sha256 hash of the image.
 SWU image signing
 ------------
 
-To enable signing:
-    Set SWUPDATE_SIGNING = "1"
-    Set SWUPDATE_PRIVATE_KEY to the full path of private key file
+There are 3 signing mechanisms supported by meta-swupdate at the moment:
 
-sw-description is signed with the private key and the signature is writen to
-sw-description.sig which is included in the SWU file.
+1. RSA signing:
 
-Encrypted private keys are not currently supported since a secure 
+  * Set variable: `SWUPDATE_SIGNING = "RSA"`
+
+  * Set `SWUPDATE_PRIVATE_KEY` to the full path of private key file
+
+2. CMS signing:
+
+  * Set variable: `SWUPDATE_SIGNING = "CMS"`
+
+  * Set `SWUPDATE_CMS_CERT` to the full path of certificate file
+
+  * Set `SWUPDATE_CMS_KEY ` to the full path of private key file
+
+3. Custom signing tool:
+
+  * Set variable: `SWUPDATE_SIGNING = "CUSTOM"`
+
+  * Set variable `SWUPDATE_SIGN_TOOL' to custom string that needs to be
+    executed in order to perform the signing
+
+sw-description is signed and the signature is written to sw-description.sig
+which is included in the SWU file.
+
+Encrypted private keys are not currently supported since a secure
 mechanism must exist to provide the passphrase.
-
-If SWUPDATE_SIGN_TOOL is set, SWUPDATE_PRIVATE_KEY is ignored and the string
-contained in SWUPDATE_SIGN_TOOL is executed to perform the signing.
 
 Maintainer
 ----------
@@ -51,5 +67,5 @@ When creating patches, please use something like:
 
     git format-patch -s --subject-prefix='meta-swupdate][PATCH' <revision range>
 
-Please use 'git send- email' to send the generated patches to the ML
+Please use 'git send-email' to send the generated patches to the ML
 to bypass changes from your mailer.

--- a/classes/swupdate.bbclass
+++ b/classes/swupdate.bbclass
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Stefano Babic <sbabic@denx.de>
-# 
+#
 # Some parts from the patch class
 #
 # swupdate allows to generate a compound image for the
@@ -14,7 +14,7 @@
 
 S = "${WORKDIR}/${PN}"
 
-DEPENDS += "${@ 'openssl-native' if d.getVar('SWUPDATE_SIGNING', True) == '1' else ''}"
+DEPENDS += "${@ 'openssl-native' if d.getVar('SWUPDATE_SIGNING', True) else ''}"
 IMAGE_DEPENDS ?= ""
 
 def swupdate_is_hash_needed(s, filename):
@@ -64,15 +64,23 @@ def swupdate_getdepends(d):
         depstr += " " + dep + ":do_build"
     return depstr
 
+IMGDEPLOYDIR = "${WORKDIR}/deploy-${PN}-swuimage"
+
 do_swuimage[dirs] = "${TOPDIR}"
-do_swuimage[cleandirs] += "${S}"
+do_swuimage[cleandirs] += "${S} ${IMGDEPLOYDIR}"
 do_swuimage[umask] = "022"
+SSTATETASKS += "do_swuimage"
+SSTATE_SKIP_CREATION_task-swuimage = '1'
+do_swuimage[sstate-inputdirs] = "${IMGDEPLOYDIR}"
+do_swuimage[sstate-outputdirs] = "${DEPLOY_DIR_IMAGE}"
+do_swuimage[stamp-extra-info] = "${MACHINE}"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 do_install[noexec] = "1"
+deltask do_populate_sysroot
 do_package[noexec] = "1"
-do_package_qa[noexec] = "1"
+deltask do_package_qa
 do_packagedata[noexec] = "1"
 do_package_write_ipk[noexec] = "1"
 do_package_write_deb[noexec] = "1"
@@ -81,14 +89,6 @@ do_package_write_rpm[noexec] = "1"
 python () {
     deps = " " + swupdate_getdepends(d)
     d.appendVarFlag('do_swuimage', 'depends', deps)
-}
-
-do_install () {
-}
-
-do_createlink () {
-    cd ${DEPLOY_DIR_IMAGE}
-    ln -sf ${IMAGE_NAME}.swu ${IMAGE_LINK_NAME}.swu
 }
 
 python do_swuimage () {
@@ -101,7 +101,7 @@ python do_swuimage () {
     fetch = bb.fetch2.Fetch([], d)
     list_for_cpio = ["sw-description"]
 
-    if d.getVar('SWUPDATE_SIGNING', True) == '1':
+    if d.getVar('SWUPDATE_SIGNING', True):
         list_for_cpio.append('sw-description.sig')
 
     for url in fetch.urls:
@@ -115,6 +115,7 @@ python do_swuimage () {
 # If they are not there, additional file can be added
 # by fetching from URLs
     deploydir = d.getVar('DEPLOY_DIR_IMAGE', True)
+    imgdeploydir = d.getVar('IMGDEPLOYDIR', True)
 
     for image in images:
         fstypes = (d.getVarFlag("SWUPDATE_IMAGES_FSTYPES", image, True) or "").split()
@@ -140,12 +141,20 @@ python do_swuimage () {
             hash = swupdate_get_sha256(s, file)
             swupdate_write_sha256(s, file, hash)
 
-    if d.getVar('SWUPDATE_SIGNING', True) == '1':
-        sign_tool = d.getVar('SWUPDATE_SIGN_TOOL', True)
-        if sign_tool:
-            if os.system(sign_tool) != 0:
-                bb.fatal("Failed to sign with %s" % (sign_tool))
-        else:
+    signing = d.getVar('SWUPDATE_SIGNING', True)
+    if signing == "1":
+        bb.warn('SWUPDATE_SIGNING = "1" is deprecated, falling back to "RSA". It is advised to set it to "RSA" if using RSA signing.')
+        signing = "RSA"
+    if signing:
+        if signing == "CUSTOM":
+            sign_tool = d.getVar('SWUPDATE_SIGN_TOOL', True)
+            if sign_tool:
+                ret = os.system(sign_tool)
+                if ret != 0:
+                    bb.fatal("Failed to sign with %s" % (sign_tool))
+            else:
+                bb.fatal("Custom SWUPDATE_SIGN_TOOL is not given")
+        elif signing == "RSA":
             privkey = d.getVar('SWUPDATE_PRIVATE_KEY', True)
             if not privkey:
                 bb.fatal("SWUPDATE_PRIVATE_KEY isn't set")
@@ -163,13 +172,38 @@ python do_swuimage () {
                 os.path.join(s, 'sw-description'))
             if os.system(signcmd) != 0:
                 bb.fatal("Failed to sign sw-description with %s" % (privkey))
+        elif signing == "CMS":
+            cms_cert = d.getVar('SWUPDATE_CMS_CERT', True)
+            if not cms_cert:
+                bb.fatal("SWUPDATE_CMS_CERT is not set")
+            if not os.path.exists(cms_cert):
+                bb.fatal("SWUPDATE_CMS_CERT %s doesn't exist" % (cms_cert))
+            cms_key = d.getVar('SWUPDATE_CMS_KEY', True)
+            if not cms_key:
+                bb.fatal("SWUPDATE_CMS_KEY isn't set")
+            if not os.path.exists(cms_key):
+                bb.fatal("SWUPDATE_CMS_KEY %s doesn't exist" % (cms_key))
+            signcmd = "openssl cms -sign -in '%s' -out '%s' -signer '%s' -inkey '%s' -outform DER -nosmimecap -binary" % (
+                os.path.join(s, 'sw-description'),
+                os.path.join(s, 'sw-description.sig'),
+                cms_cert,
+                cms_key)
+            if os.system(signcmd) != 0:
+                bb.fatal("Failed to sign sw-description with %s" % (privkey))
+        else:
+            bb.fatal("Unrecognized SWUPDATE_SIGNING mechanism.");
 
-    line = 'for i in ' + ' '.join(list_for_cpio) + '; do echo $i;done | cpio -ov -H crc >' + os.path.join(deploydir,d.getVar('IMAGE_NAME', True) + '.swu')
+    line = 'for i in ' + ' '.join(list_for_cpio) + '; do echo $i;done | cpio -ov -H crc >' + os.path.join(imgdeploydir,d.getVar('IMAGE_NAME', True) + '.swu')
     os.system("cd " + s + ";" + line)
+
+    line = 'ln -sf ' + d.getVar('IMAGE_NAME', True) + '.swu ' + d.getVar('IMAGE_LINK_NAME', True) + '.swu'
+    os.system("cd " + imgdeploydir + "; " + line)
 }
 
 COMPRESSIONTYPES = ""
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-addtask do_swuimage after do_unpack before do_install
-addtask do_createlink after do_swuimage before do_install
+INHIBIT_DEFAULT_DEPS = "1"
+EXCLUDE_FROM_WORLD = "1"
+
+addtask do_swuimage after do_unpack after do_prepare_recipe_sysroot before do_build


### PR DESCRIPTION
This commit brings the latest version of swupdate.bbclass from `master`
into `morty`. README file is also copied over. This adds support for
CMS signing and few other conveniences to `morty`.